### PR TITLE
Pin kernel, bootloader and libraspberrypi-* versions

### DIFF
--- a/stages/03-Packages/00-run-chroot.sh
+++ b/stages/03-Packages/00-run-chroot.sh
@@ -14,6 +14,10 @@ apt-mark hold raspberrypi-kernel
 # Install kernel-headers before apt-get update
 DEBIAN_FRONTEND=noninteractive sudo apt-get -yq install raspberrypi-kernel-headers
 
+# Install libraspberrypi-dev before apt-get update
+DEBIAN_FRONTEND=noninteractive sudo apt-get -yq install libraspberrypi-dev libraspberrypi-dev libraspberrypi-bin libraspberrypi0
+apt-mark hold libraspberrypi-dev libraspberrypi-bin libraspberrypi0
+
 # Latest package source
 # sudo rm -rf /var/lib/apt/lists/*
 # sudo apt-get clean
@@ -95,7 +99,7 @@ DEBIAN_FRONTEND=noninteractive sudo apt-get install build-essential \
                                                     libfontconfig1-dev libdbus-1-dev \
                                                     libfreetype6-dev libicu-dev libinput-dev \
                                                     libxkbcommon-dev libsqlite3-dev libssl-dev libpng-dev \
-                                                    libjpeg-dev libglib2.0-dev libraspberrypi-dev \
+                                                    libjpeg-dev libglib2.0-dev \
                                                     libasound2-dev pulseaudio libpulse-dev
 
 DEBIAN_FRONTEND=noninteractive sudo apt-get install libudev-dev libinput-dev libts-dev mtdev-tools

--- a/stages/03-Packages/00-run-chroot.sh
+++ b/stages/03-Packages/00-run-chroot.sh
@@ -8,6 +8,9 @@
 rm /lib/modules/4.14.71*/build
 rm /lib/modules/4.14.71*/source
 
+apt-mark hold raspberrypi-bootloader
+apt-mark hold raspberrypi-kernel
+
 # Install kernel-headers before apt-get update
 DEBIAN_FRONTEND=noninteractive sudo apt-get -yq install raspberrypi-kernel-headers
 


### PR DESCRIPTION
This will force the kernel, bootloader, and `libraspberrypi-*` packages to remain at their current preinstalled versions that shipped on the raspbian base image we use, regardless of what the package manager tries to do later on, even after apt update is run.

If we update the image at some point there won't be any changes necessary to make the pinning keep working, it's automatic.