### PR TITLE
Delete QOpenHD build directory after installation

### DIFF
--- a/stages/05-Wifibroadcast/01-run-chroot.sh
+++ b/stages/05-Wifibroadcast/01-run-chroot.sh
@@ -138,6 +138,7 @@ cd /home/pi/QOpenHD
 make -j5 || exit 1
 cp -a release/QOpenHD "/usr/local/bin/QOpenHD" || exit 1
 cd ..
+rm -rf QOpenHD
 
 # install picamera
 apt-get --yes --force-yes install python3-picamera


### PR DESCRIPTION
This build directory doesn't need to be on the image and just wastes space