### PR TITLE
Fix shell prompt

### DIFF
--- a/stages/05-Wifibroadcast/FILES/overlay/etc/bash.bashrc
+++ b/stages/05-Wifibroadcast/FILES/overlay/etc/bash.bashrc
@@ -61,8 +61,8 @@ set_bash_prompt(){
     PS1='\[\033[01;32m\]\u@\h${boot_fs_mode:+(boot:$boot_fs_mode,root:$root_fs_mode)}\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
 }
 
-alias ro='mount -o remount,ro / ; mount -o remount,ro /boot'
-alias rw='mount -o remount,rw / ; mount -o remount,rw /boot' 
+alias ro='mount -o remount,ro /boot'
+alias rw='mount -o remount,rw /boot'
 
 # setup fancy prompt"
 PROMPT_COMMAND=set_bash_prompt

--- a/stages/05-Wifibroadcast/FILES/overlay/etc/bash.bashrc
+++ b/stages/05-Wifibroadcast/FILES/overlay/etc/bash.bashrc
@@ -56,8 +56,9 @@ fi
 
 
 set_bash_prompt(){
-    fs_mode=$(mount | sed -n -e "s/^\/dev\/.* on \/ .*(\(r[w|o]\).*/\1/p")
-    PS1='\[\033[01;32m\]\u@\h${fs_mode:+($fs_mode)}\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+    boot_fs_mode=$(mount | sed -n -e "s/^\/dev\/.* on \/boot .*(\(r[w|o]\).*/\1/p")
+	root_fs_mode=$(mount | sed -n -e "s/^\/dev\/.* on \/ .*(\(r[w|o]\).*/\1/p")
+    PS1='\[\033[01;32m\]\u@\h${boot_fs_mode:+(boot:$boot_fs_mode,root:$root_fs_mode)}\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
 }
 
 alias ro='mount -o remount,ro / ; mount -o remount,ro /boot'


### PR DESCRIPTION
This changes the shell prompt to the following format:

`root@wbc(boot:ro,root:rw):/home/pi# `

This will accurately show the partition mount states at all times since they are no longer always the same.

This PR also changes the `rw` and `ro` bash aliases so they no longer modify the root partition mount state, it is always read-write now and shouldn't be changed.