### PR TITLE
Install mavlink-routerd to /usr/local/bin

### DIFF
--- a/stages/04-Support/01-run-chroot.sh
+++ b/stages/04-Support/01-run-chroot.sh
@@ -14,9 +14,9 @@ sudo make install
 cd /home/pi
 cd mavlink-router
 sudo ./autogen.sh && sudo ./configure CFLAGS='-g -O2' \
-        --sysconfdir=/etc --localstatedir=/var --libdir=/usr/lib64 \
-    --prefix=/usr
-sudo make
+        --sysconfdir=/etc --localstatedir=/var --libdir=/usr/local/lib64 \
+    --prefix=/usr/local
+sudo make install
 
 # Install cmavnode
 cd /home/pi


### PR DESCRIPTION
This allows us to delete the build directory and save 107MB of wasted space on the SD card