### PR TITLE
Add support for apt-cacher-ng in builder

### DIFF
--- a/config
+++ b/config
@@ -10,6 +10,9 @@ BASE_IMAGE="2018-10-09-raspbian-stretch-lite"
 # Amount of cores to use for compilation on host machine
 J_CORES=12
 
+APT_CACHER_NG_URL=http://127.0.0.1:3142
+APT_CACHER_NG_ENABLED=false
+
 
 PI_TOOLS_REPO=https://github.com/raspberrypi/tools.git
 PI_TOOLS_BRANCH=master

--- a/stages/03-Packages/00-run-chroot.sh
+++ b/stages/03-Packages/00-run-chroot.sh
@@ -8,6 +8,12 @@
 rm /lib/modules/4.14.71*/build
 rm /lib/modules/4.14.71*/source
 
+if [ ${APT_CACHER_NG_ENABLED} == "true" ]; then
+    echo "Acquire::http::Proxy \"${APT_CACHER_NG_URL}/\";" >> /etc/apt/apt.conf.d/10cache
+fi
+
+
+
 apt-mark hold raspberrypi-bootloader
 apt-mark hold raspberrypi-kernel
 
@@ -157,3 +163,7 @@ sudo apt-get -y install python3-rpi.gpio
 # Clean Up
 DEBIAN_FRONTEND=noninteractive sudo apt-get -yq clean
 DEBIAN_FRONTEND=noninteractive sudo apt-get -yq autoremove
+
+if [ ${APT_CACHER_NG_ENABLED} == "true" ]; then
+    rm /etc/apt/apt.conf.d/10cache
+fi


### PR DESCRIPTION
With this change, if you install apt-cacher-ng on your build machine
and enable it to cache raspbian packages (if it doesn't by default),
the first time you run a build the packages being installed in stage3
will be cached on your build machine. Then the next time you run a new
build, it will get those packages from apt-cacher-ng almost instantly
instead of having to download them again. The speedup is massive, 10
minutes vs over an hour depending on the connection speed