### PR TITLE
Use our own fork+branch of mavlink-router

### DIFF
--- a/config
+++ b/config
@@ -27,8 +27,8 @@ V4L2LOOPBACK_BRANCH=master
 RASPI2PNG_REPO=https://github.com/AndrewFromMelbourne/raspi2png.git
 RASPI2PNG_BRANCH=master
 
-MAVLINK_ROUTER_REPO=https://github.com/user1321/mavlink-router.git
-MAVLINK_ROUTER_BRANCH=rock64
+MAVLINK_ROUTER_REPO=https://github.com/OpenHD/mavlink-router.git
+MAVLINK_ROUTER_BRANCH=openhd
 
 PYMAVLINK_REPO=https://github.com/user1321/pymavlink.git
 PYMAVLINK_BRANCH=master


### PR DESCRIPTION
This will allow us to keep the mavlink-router code updated when necessary (we don't control the old repo the builder was cloning it from), but still prevent it from changing randomly (we don't directly use the upstream intel repo).

This branch still has the dynamic endpoint patch applied, but not the DTR/CTR change that was present in the rock64 branch, because that code no longer exists upstream so we don't need to disable or change it anymore.
