### PR TITLE
Re-enable mouse pointer in QOpenHD

### DIFF
--- a/stages/05-Wifibroadcast/FILES/overlay/etc/systemd/system/qopenhd.service
+++ b/stages/05-Wifibroadcast/FILES/overlay/etc/systemd/system/qopenhd.service
@@ -4,7 +4,6 @@ After=multi-user.target
 
 [Service]
 Type=simple
-Environment="QT_QPA_EGLFS_HIDECURSOR=1"
 Environment="LD_PRELOAD=/opt/vc/lib/libGLESv2.so /opt/vc/lib/libEGL.so"
 ExecStart=/usr/local/bin/QOpenHD -platform eglfs
 User=root

--- a/stages/05-Wifibroadcast/FILES/overlay/usr/local/bin/run_qopenhd
+++ b/stages/05-Wifibroadcast/FILES/overlay/usr/local/bin/run_qopenhd
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-QT_QPA_EGLFS_HIDECURSOR=1 LD_PRELOAD="/opt/vc/lib/libGLESv2.so /opt/vc/lib/libEGL.so" /usr/local/bin/QOpenHD -platform eglfs
+LD_PRELOAD="/opt/vc/lib/libGLESv2.so /opt/vc/lib/libEGL.so" /usr/local/bin/QOpenHD -platform eglfs


### PR DESCRIPTION
Qt seems to do the right thing, hiding it by default unless a mouse is connected so we can enable it again.

This allows use of mice and other pointing devices on the ground station.