### PR TITLE
Fix settings note about VIDEO_BITRATE

### DIFF
--- a/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-1.txt
+++ b/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-1.txt
@@ -87,7 +87,11 @@ Bandwidth=20
 
 # >>>>>>>>>>[VIDEO BITRATE]-- "auto" recommended
 # Air Pi reads available bandwidth to determine bitrate.
-# *Set to a fixed value to disable automatic measuring (Example: For 4.5mbit, Set: "4500000"
+# 
+# Set to a fixed value to disable automatic measuring 
+# 
+# Note: the unit for this setting is kilobits, not megabits or bits!
+# For 4.5mbit, set to 4500
 VIDEO_BITRATE=auto
 
 # >>>>>>>>>>[BITRATE PERCENTAGE]-- "65 default"

--- a/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-2.txt
+++ b/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-2.txt
@@ -58,7 +58,11 @@ Bandwidth=20
 
 # >>>>>>>>>>[VIDEO BITRATE]-- "auto" recommended
 # Air Pi reads available bandwidth to determine bitrate.
-# *Set to a fixed value to disable automatic measuring
+# 
+# Set to a fixed value to disable automatic measuring 
+# 
+# Note: the unit for this setting is kilobits, not megabits or bits!
+# For 4.5mbit, set to 4500
 VIDEO_BITRATE=auto
 
 # >>>>>>>>>>[BITRATE PERCENTAGE]-- "65 default"

--- a/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-3.txt
+++ b/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-3.txt
@@ -58,7 +58,11 @@ Bandwidth=20
 
 # >>>>>>>>>>[VIDEO BITRATE]-- "auto" recommended
 # Air Pi reads available bandwidth to determine bitrate.
-# *Set to a fixed value to disable automatic measuring
+# 
+# Set to a fixed value to disable automatic measuring 
+# 
+# Note: the unit for this setting is kilobits, not megabits or bits!
+# For 4.5mbit, set to 4500
 VIDEO_BITRATE=auto
 
 # >>>>>>>>>>[BITRATE PERCENTAGE]-- "65 default"

--- a/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-4.txt
+++ b/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-4.txt
@@ -58,7 +58,11 @@ Bandwidth=20
 
 # >>>>>>>>>>[VIDEO BITRATE]-- "auto" recommended
 # Air Pi reads available bandwidth to determine bitrate.
-# *Set to a fixed value to disable automatic measuring
+# 
+# Set to a fixed value to disable automatic measuring 
+# 
+# Note: the unit for this setting is kilobits, not megabits or bits!
+# For 4.5mbit, set to 4500
 VIDEO_BITRATE=auto
 
 # >>>>>>>>>>[BITRATE PERCENTAGE]-- "65 default"


### PR DESCRIPTION
The code expects this to be kilobits per second, but the note in the file suggests it's just bits per second and gives an incorrect example.

Note that when setting the video bitrate manually, the measured bitrate value in the OSD is not real and will be corrected in another PR.