### PR TITLE
Update VIDEO_BITRATE units to match recent change

### DIFF
--- a/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-1.txt
+++ b/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-1.txt
@@ -90,8 +90,8 @@ Bandwidth=20
 # 
 # Set to a fixed value to disable automatic measuring 
 # 
-# Note: the unit for this setting is kilobits, not megabits or bits!
-# For 4.5mbit, set to 4500
+# Note: the unit for this setting is megabits, not kilobits or bits!
+# For 4.5mbit, set to 4.5
 VIDEO_BITRATE=auto
 
 # >>>>>>>>>>[BITRATE PERCENTAGE]-- "65 default"

--- a/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-2.txt
+++ b/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-2.txt
@@ -61,8 +61,8 @@ Bandwidth=20
 # 
 # Set to a fixed value to disable automatic measuring 
 # 
-# Note: the unit for this setting is kilobits, not megabits or bits!
-# For 4.5mbit, set to 4500
+# Note: the unit for this setting is megabits, not kilobits or bits!
+# For 4.5mbit, set to 4.5
 VIDEO_BITRATE=auto
 
 # >>>>>>>>>>[BITRATE PERCENTAGE]-- "65 default"

--- a/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-3.txt
+++ b/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-3.txt
@@ -61,8 +61,8 @@ Bandwidth=20
 # 
 # Set to a fixed value to disable automatic measuring 
 # 
-# Note: the unit for this setting is kilobits, not megabits or bits!
-# For 4.5mbit, set to 4500
+# Note: the unit for this setting is megabits, not kilobits or bits!
+# For 4.5mbit, set to 4.5
 VIDEO_BITRATE=auto
 
 # >>>>>>>>>>[BITRATE PERCENTAGE]-- "65 default"

--- a/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-4.txt
+++ b/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-4.txt
@@ -61,8 +61,8 @@ Bandwidth=20
 # 
 # Set to a fixed value to disable automatic measuring 
 # 
-# Note: the unit for this setting is kilobits, not megabits or bits!
-# For 4.5mbit, set to 4500
+# Note: the unit for this setting is megabits, not kilobits or bits!
+# For 4.5mbit, set to 4.5
 VIDEO_BITRATE=auto
 
 # >>>>>>>>>>[BITRATE PERCENTAGE]-- "65 default"


### PR DESCRIPTION
The Open.HD repo now assumes this setting is in megabits to make
things easier for users, this updates the documentation to match.