### PR TITLE
Add setting for USB video save format to use

### DIFF
--- a/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-1.txt
+++ b/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-1.txt
@@ -350,6 +350,12 @@ RELAY_FREQ=5220
 # VIDEO_FS set to "ext4" (Linux, which is recommended for performance) or "fat" (Windows)
 VIDEO_FS=ext4
 
+# >>>>>>>>>>[CHANGE TMP VIDEO PARTITION TYPE]--
+# VIDEO_SAVE_FORMAT sets the container used when saving video to a USB stick on the ground station.
+# You can choose any format that ffmpeg can handle, the default is still avi but mp4 is broadly compatible
+# with most devices now as well. The default may change soon.
+VIDEO_SAVE_FORMAT=avi
+
 # >>>>>>>>>>[AIRODUMP Y/N]--Set to "Y" to scan for wifi networks with airodump-ng before starting RX
 AIRODUMP=N
 # Number of seconds wifi scanner is shown. Minimum recommended scanning time is 25 seconds.

--- a/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-2.txt
+++ b/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-2.txt
@@ -317,6 +317,12 @@ RELAY_FREQ=5220
 # >>>>>>>>>>[CHANGE TMP VIDEO PARTITION TYPE]--
 VIDEO_FS=ext4
 
+# >>>>>>>>>>[CHANGE TMP VIDEO PARTITION TYPE]--
+# VIDEO_SAVE_FORMAT sets the container used when saving video to a USB stick on the ground station.
+# You can choose any format that ffmpeg can handle, the default is still avi but mp4 is broadly compatible
+# with most devices now as well. The default may change soon.
+VIDEO_SAVE_FORMAT=avi
+
 # >>>>>>>>>>[AIRODUMP Y/N]--Set to "Y" to scan for wifi networks with airodump-ng before starting RX
 AIRODUMP=N
 # Number of seconds wifi scanner is shown. Minimum recommended scanning time is 25 seconds.

--- a/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-3.txt
+++ b/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-3.txt
@@ -317,6 +317,12 @@ RELAY_FREQ=5220
 # >>>>>>>>>>[CHANGE TMP VIDEO PARTITION TYPE]--
 VIDEO_FS=ext4
 
+# >>>>>>>>>>[CHANGE TMP VIDEO PARTITION TYPE]--
+# VIDEO_SAVE_FORMAT sets the container used when saving video to a USB stick on the ground station.
+# You can choose any format that ffmpeg can handle, the default is still avi but mp4 is broadly compatible
+# with most devices now as well. The default may change soon.
+VIDEO_SAVE_FORMAT=avi
+
 # >>>>>>>>>>[AIRODUMP Y/N]--Set to "Y" to scan for wifi networks with airodump-ng before starting RX
 AIRODUMP=N
 # Number of seconds wifi scanner is shown. Minimum recommended scanning time is 25 seconds.

--- a/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-4.txt
+++ b/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-4.txt
@@ -317,6 +317,12 @@ RELAY_FREQ=5220
 # >>>>>>>>>>[CHANGE TMP VIDEO PARTITION TYPE]--
 VIDEO_FS=ext4
 
+# >>>>>>>>>>[CHANGE TMP VIDEO PARTITION TYPE]--
+# VIDEO_SAVE_FORMAT sets the container used when saving video to a USB stick on the ground station.
+# You can choose any format that ffmpeg can handle, the default is still avi but mp4 is broadly compatible
+# with most devices now as well. The default may change soon.
+VIDEO_SAVE_FORMAT=avi
+
 # >>>>>>>>>>[AIRODUMP Y/N]--Set to "Y" to scan for wifi networks with airodump-ng before starting RX
 AIRODUMP=N
 # Number of seconds wifi scanner is shown. Minimum recommended scanning time is 25 seconds.


### PR DESCRIPTION
This is directly used by the `ffmpeg` command, so it can be set to any file extension `ffmpeg` understands.