### PR TITLE
Don't hide console output

### DIFF
--- a/stages/05-Wifibroadcast/FILES/overlay/boot/cmdline.txt
+++ b/stages/05-Wifibroadcast/FILES/overlay/boot/cmdline.txt
@@ -1,1 +1,1 @@
-dwc_otg.lpm_enable=0 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 nofsck elevator=deadline fsck.mode=skip noswap rootwait consoleblank=0 loglevel=0 vt.global_cursor_default=0 fbcon=map:2 dwc_otg.fiq_fsm_enable=0 dwc_otg.fiq_enable=0 dwc_otg.nak_holdoff=0 dwc_otg.int_ep_interval_min=0 quiet 
+dwc_otg.lpm_enable=0 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 nofsck elevator=deadline fsck.mode=skip noswap rootwait consoleblank=0 loglevel=0 vt.global_cursor_default=0 dwc_otg.fiq_fsm_enable=0 dwc_otg.fiq_enable=0 dwc_otg.nak_holdoff=0 dwc_otg.int_ep_interval_min=0 


### PR DESCRIPTION
This just makes it difficult to tell what's going on if something isn't working, and difficult for others to help them since they can't see what went wrong.