### PR TITLE
Add package firmware-misc-nonfree

### DIFF
--- a/stages/03-Packages/00-run-chroot.sh
+++ b/stages/03-Packages/00-run-chroot.sh
@@ -59,6 +59,7 @@ DEBIAN_FRONTEND=noninteractive sudo apt-get -yq install libfontconfig1-dev
 DEBIAN_FRONTEND=noninteractive sudo apt-get -yq install libsdl2-dev
 DEBIAN_FRONTEND=noninteractive sudo apt-get -yq install libsdl1.2-dev
 DEBIAN_FRONTEND=noninteractive sudo apt-get -yq install libav-tools
+DEBIAN_FRONTEND=noninteractive sudo apt-get -yq install firmware-misc-nonfree
 
 # text to speech for QOpenHD
 DEBIAN_FRONTEND=noninteractive sudo apt-get -yq install libspeechd-dev flite1-dev flite speech-dispatcher-flite --no-install-recommends


### PR DESCRIPTION
This just installs the firmware for a handful of hardware devices, most of which are never connected to an OpenHD ground/air pi, except for the rt2800usb. We don't currently ship our own firmware for this device so there's no conflict pulling in a package for it.

The linked issue says this is all that's needed to make that device work in OpenHD, but I can't test it myself.

See https://github.com/OpenHD/Open.HD/issues/196