### PR TITLE
Limit clone depth for all cloned repos

### DIFF
--- a/stages/00-Prerequisites/00-run.sh
+++ b/stages/00-Prerequisites/00-run.sh
@@ -2,7 +2,7 @@ log "Checking prerequisites"
 
 if [ ! -d ~/tools ]; then
     log "Download the Raspberry Pi Tools"
-    git clone -b ${PI_TOOLS_BRANCH} ${PI_TOOLS_REPO} ~/tools
+    git clone --depth=1 -b ${PI_TOOLS_BRANCH} ${PI_TOOLS_REPO} ~/tools
     log "Install the Raspberry Pi Tools"
     echo PATH=\$PATH:~/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian/bin >> ~/.bashrc
     source ~/.bashrc

--- a/stages/02-Kernel/00-run.sh
+++ b/stages/02-Kernel/00-run.sh
@@ -5,7 +5,7 @@ pushd ${STAGE_WORK_DIR}
 
 if [ ! -d "linux" ]; then
     log "Download the Raspberry Pi Kernel"
-    git clone --depth=100 -b ${PI_KERNEL_BRANCH} ${PI_KERNEL_REPO}
+    git clone --depth=1 -b ${PI_KERNEL_BRANCH} ${PI_KERNEL_REPO}
 fi
 
 pushd linux
@@ -20,11 +20,11 @@ popd
 
 log "Download the rtl8812au drivers"
 rm -r rtl8812au || true
-git clone -b ${RTL_8812AU_BRANCH} ${RTL_8812AU_REPO}
+git clone --depth=1 -b ${RTL_8812AU_BRANCH} ${RTL_8812AU_REPO}
 
 log "Download the v4l2loopback module"
 rm -r v4l2loopback || true
-git clone -b ${V4L2LOOPBACK_BRANCH} ${V4L2LOOPBACK_REPO}
+git clone --depth=1 -b ${V4L2LOOPBACK_BRANCH} ${V4L2LOOPBACK_REPO}
 
 #return 
 popd

--- a/stages/04-Support/00-run.sh
+++ b/stages/04-Support/00-run.sh
@@ -26,28 +26,28 @@ mv Qt${QT_MAJOR_VERSION}.${QT_MINOR_VERSION} ${MNT_DIR}/opt/ || exit 1
 rm -f Qt${QT_MAJOR_VERSION}.${QT_MINOR_VERSION}.tar.gz
 
 log "Download LiFePO4wered-pi"
-git clone -b ${LIFEPOWEREDPI_BRANCH} ${LIFEPOWEREDPI_REPO} || exit 1
+git clone --depth=1 -b ${LIFEPOWEREDPI_BRANCH} ${LIFEPOWEREDPI_REPO} || exit 1
 
 log "Download OpenHDMicroservice"
-git clone -b ${OPENHDMICROSERVICE_BRANCH} ${OPENHDMICROSERVICE_REPO} || exit 1
+git clone --depth=1 -b ${OPENHDMICROSERVICE_BRANCH} ${OPENHDMICROSERVICE_REPO} || exit 1
 
 log "Download Raspi2png"
-git clone -b ${RASPI2PNG_BRANCH} ${RASPI2PNG_REPO} || exit 1
+git clone --depth=1 -b ${RASPI2PNG_BRANCH} ${RASPI2PNG_REPO} || exit 1
 
 log "Download Mavlink router"
-sudo git clone -b ${MAVLINK_ROUTER_BRANCH} ${MAVLINK_ROUTER_REPO} || exit 1
+sudo git clone --depth=1 -b ${MAVLINK_ROUTER_BRANCH} ${MAVLINK_ROUTER_REPO} || exit 1
 pushd mavlink-router
 sudo git submodule update --init || exit 1
 
 #fix missing pymavlink
 pushd modules/mavlink
-sudo git clone --recurse-submodules -b ${PYMAVLINK_BRANCH} ${PYMAVLINK_REPO} || exit 1
+sudo git clone --depth=1 --recurse-submodules -b ${PYMAVLINK_BRANCH} ${PYMAVLINK_REPO} || exit 1
 popd
 
 popd
 
 log "Download cmavnode"
-sudo git clone -b ${CMAVNODE_BRANCH} ${CMAVNODE_REPO} || exit 1
+sudo git clone --depth=1 -b ${CMAVNODE_BRANCH} ${CMAVNODE_REPO} || exit 1
 pushd cmavnode
 sudo git submodule update --init || exit 1
 popd

--- a/stages/05-Wifibroadcast/01-run.sh
+++ b/stages/05-Wifibroadcast/01-run.sh
@@ -11,7 +11,7 @@ pushd GIT
 MNT_DIR="${STAGE_WORK_DIR}/mnt"
 
 log "Download all Open.HD Sources"
-sudo git clone -b ${OPENHD_BRANCH} ${OPENHD_REPO} || exit 1
+sudo git clone  --depth=1 -b ${OPENHD_BRANCH} ${OPENHD_REPO} || exit 1
 pushd Open.HD
 sudo git submodule update --init || exit 1
 OPENHD_VERSION=$(git describe --always --tags)
@@ -66,7 +66,7 @@ log "Download EZWFB - Splash"
 sudo mv Open.HD/wifibroadcast-splash/ wifibroadcast-splash/
 
 log "Download FLIR one"
-sudo git clone -b ${OPENHD_FLIRONE_DRIVER_BRANCH} ${OPENHD_FLIRONE_DRIVER_REPO}
+sudo git clone --depth=1 -b ${OPENHD_FLIRONE_DRIVER_BRANCH} ${OPENHD_FLIRONE_DRIVER_REPO}
 
 log "Download RemoteSettings"
 # sudo git clone -b user1321-5MhzAth9k https://github.com/user1321/RemoteSettings
@@ -99,7 +99,7 @@ sudo mv Open.HD/UDPSplitter/ UDPSplitter/
 sudo rm -rf Open.HD
 
 
-git clone -b ${QOPENHD_VERSION} ${QOPENHD_REPO} || exit 1
+git clone --depth=1 -b ${QOPENHD_VERSION} ${QOPENHD_REPO} || exit 1
 cd QOpenHD
 git submodule update --init --recursive || exit 1
 echo ${OPENHD_VERSION} > .openhd_version


### PR DESCRIPTION
Some of the repos are really huge, Open.HD is ~240MB and gets cloned again every single build, which downloads git objects that aren't even referenced anymore.