### PR TITLE
Lte video

### DIFF
--- a/stages/05-Wifibroadcast/01-run-chroot.sh
+++ b/stages/05-Wifibroadcast/01-run-chroot.sh
@@ -142,3 +142,12 @@ rm -rf QOpenHD
 
 # install picamera
 apt-get --yes --force-yes install python3-picamera
+
+# install zerotier
+wget -O z.sh https://install.zerotier.com/
+chmod +x z.sh
+./z.sh 
+sudo cat /var/lib/zerotier-one/authtoken.secret >>.zeroTierOneAuthToken
+chmod 0600 .zeroTierOneAuthToken
+sudo apt install lsof
+

--- a/stages/05-Wifibroadcast/01-run-chroot.sh
+++ b/stages/05-Wifibroadcast/01-run-chroot.sh
@@ -144,10 +144,29 @@ rm -rf QOpenHD
 apt-get --yes --force-yes install python3-picamera
 
 # install zerotier
-wget -O z.sh https://install.zerotier.com/
-chmod +x z.sh
-./z.sh 
-sudo cat /var/lib/zerotier-one/authtoken.secret >>.zeroTierOneAuthToken
-chmod 0600 .zeroTierOneAuthToken
-sudo apt install lsof
+#wget -O z.sh https://install.zerotier.com/
+#chmod +x z.sh
+#./z.sh 
+#sudo cat /var/lib/zerotier-one/authtoken.secret >>.zeroTierOneAuthToken
+#chmod 0600 .zeroTierOneAuthToken
+#sudo apt install lsof
+curl -s https://install.zerotier.com | sudo bash
 
+# Add zerotier config file
+sudo touch /var/lib/zerotier-one/local.conf
+sudo echo '{
+        "settings": {
+                "interfacePrefixBlacklist": [ "eth0" ],
+                "interfacePrefixBlacklist": [ "wifihotspot0" ],
+                "interfacePrefixBlacklist": [ "c4e984d75e95" ],
+                "allowTcpFallbackRelay": false
+        }
+}
+
+{
+        "settings": {
+                "interfacePrefixBlacklist": [ "eth0","wifihotspot0","c4e984d75e95","lo" ],
+                "allowTcpFallbackRelay": false
+        }
+}
+' >> /var/lib/zerotier-one/local.conf

--- a/stages/05-Wifibroadcast/03-run-chroot.sh
+++ b/stages/05-Wifibroadcast/03-run-chroot.sh
@@ -35,25 +35,7 @@ sudo systemctl enable wbcconfig.service
 sudo systemctl start wbcconfig.service
 
 # Disable ZeroTier service
-sudo systemctl disable zerotier-one
-# Add zerotier config file
-sudo touch /var/lib/zerotier-one/local.conf
-sudo echo '{
-        "settings": {
-                "interfacePrefixBlacklist": [ "eth0" ],
-                "interfacePrefixBlacklist": [ "wifihotspot0" ],
-                "interfacePrefixBlacklist": [ "c4e984d75e95" ],
-                "allowTcpFallbackRelay": false
-        }
-}
-
-{
-        "settings": {
-                "interfacePrefixBlacklist": [ "eth0","wifihotspot0","c4e984d75e95","lo" ],
-                "allowTcpFallbackRelay": false
-        }
-}
-' >> /var/lib/zerotier-one/local.conf
+#sudo systemctl disable zerotier-one
 
 # Copy tty autologin stuff
 cd /etc/systemd/system/getty.target.wants

--- a/stages/05-Wifibroadcast/03-run-chroot.sh
+++ b/stages/05-Wifibroadcast/03-run-chroot.sh
@@ -34,6 +34,26 @@ sudo mkfifo /root/mspfifo
 sudo systemctl enable wbcconfig.service
 sudo systemctl start wbcconfig.service
 
+# Disable ZeroTier service
+sudo systemctl disable zerotier-one
+# Add zerotier config file
+sudo touch /var/lib/zerotier-one/local.conf
+sudo echo '{
+        "settings": {
+                "interfacePrefixBlacklist": [ "eth0" ],
+                "interfacePrefixBlacklist": [ "wifihotspot0" ],
+                "interfacePrefixBlacklist": [ "c4e984d75e95" ],
+                "allowTcpFallbackRelay": false
+        }
+}
+
+{
+        "settings": {
+                "interfacePrefixBlacklist": [ "eth0","wifihotspot0","c4e984d75e95","lo" ],
+                "allowTcpFallbackRelay": false
+        }
+}
+' >> /var/lib/zerotier-one/local.conf
 
 # Copy tty autologin stuff
 cd /etc/systemd/system/getty.target.wants

--- a/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-1.txt
+++ b/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-1.txt
@@ -443,6 +443,8 @@ Lora=0
 LTE=Y
 # Must blacklist the LTE stick so it is not used for telemetry
 NIC_BLACKLIST=ztrf2varxz
+# Zerotier network ID
+ZEROTIER=1d71939404c3d2fd
 
 # >>>>>>>>>>[Adjust LCD screen backlight using touchscreen]--
 AdjustLCDBacklight=Y

--- a/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-1.txt
+++ b/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-1.txt
@@ -438,6 +438,12 @@ ActivateChannel=0
 # Values "0" or "1"
 Lora=0
 
+# >>>>>>>>>>[LTE]--Under Development
+# Enable LTE. Y or N
+LTE=Y
+# Must blacklist the LTE stick so it is not used for telemetry
+NIC_BLACKLIST=ztrf2varxz
+
 # >>>>>>>>>>[Adjust LCD screen backlight using touchscreen]--
 AdjustLCDBacklight=Y
 # Time in seconds

--- a/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-1.txt
+++ b/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-1.txt
@@ -441,7 +441,7 @@ Lora=0
 # >>>>>>>>>>[LTE]--Under Development
 # Enable LTE. Y or N
 LTE=Y
-# Must blacklist the LTE stick so it is not used for telemetry
+# Must blacklist the LTE/ZEROTIER stick so it is not used for telemetry
 NIC_BLACKLIST=ztrf2varxz
 # Zerotier network ID
 ZEROTIER=1d71939404c3d2fd

--- a/stages/05-Wifibroadcast/FILES/overlay/etc/network/interfaces
+++ b/stages/05-Wifibroadcast/FILES/overlay/etc/network/interfaces
@@ -1,0 +1,12 @@
+auto lo
+iface lo inet loopback
+auto eth0
+allow-hotplug eth0
+iface eth0 inet manual
+iface wlan0 inet manual
+iface wlan1 inet manual
+iface wlan2 inet manual
+auto eth1
+allow-hotplug eth1
+iface eth1 inet dhcp
+


### PR DESCRIPTION
First iteration of lte support in openhd. This only sends video from airpi to zerotier network. Clients with zerotier network access can then view video via udp