### PR TITLE
Remove unused RC code

### DIFF
--- a/install_script.sh
+++ b/install_script.sh
@@ -125,13 +125,6 @@ sudo make
 #sudo make clean
 #sudo make
 
-#install wifibroadcast-rc
-cd /home/pi
-#sudo git clone https://github.com/RespawnDespair/wifibroadcast-rc.git
-cd wifibroadcast-rc
-sudo chmod +x build.sh
-#sudo ./build.sh
-
 #install wifibroadcast-status
 cd /home/pi
 cd wifibroadcast-status

--- a/stages/05-Wifibroadcast/01-run-chroot.sh
+++ b/stages/05-Wifibroadcast/01-run-chroot.sh
@@ -24,10 +24,6 @@ cd wifibroadcast-base
 sudo make clean
 sudo make
 
-#install wifibroadcast-rc
-cd /home/pi
-cd wifibroadcast-rc
-sudo chmod +x build.sh
 
 #install wifibroadcast-status
 cd /home/pi
@@ -115,9 +111,6 @@ make
 
 sudo chmod 775 /home/pi/wifibroadcast-rc-Ath9k/rctxUDP.sh
 sudo chmod 775 /home/pi/wifibroadcast-rc-Ath9k/rctxUDP_IN
-
-sudo chmod 775 /home/pi/wifibroadcast-rc/rctxUDP.sh
-sudo chmod 775 /home/pi/wifibroadcast-rc/rctxUDP_IN
 
 cd /home/pi/wifibroadcast-rc-Ath9k
 sudo chmod 775 /home/pi/wifibroadcast-rc-Ath9k/buildlora.sh

--- a/stages/05-Wifibroadcast/01-run.sh
+++ b/stages/05-Wifibroadcast/01-run.sh
@@ -40,8 +40,6 @@ sudo mv Open.HD/wifibroadcast-osd/ wifibroadcast-osd/
 sudo cp -r Open.HD/mavlink/ wifibroadcast-osd/mavlink/
 
 log "Download EZWFB - RC"
-# sudo git clone https://github.com/user1321/wifibroadcast-rc-orig.git wifibroadcast-rc
-sudo mv Open.HD/wifibroadcast-rc/ wifibroadcast-rc/
 # sudo git clone -b user1321-5MHzAth9k https://github.com/user1321/wifibroadcast-rc-orig.git wifibroadcast-rc-Ath9k
 sudo mv Open.HD/wifibroadcast-rc-Ath9k/ wifibroadcast-rc-Ath9k/
 
@@ -75,10 +73,6 @@ sudo mv Open.HD/RemoteSettings/ RemoteSettings/
 log "Download cameracontrol"
 # sudo git clone https://github.com/user1321/cameracontrol
 sudo mv Open.HD/cameracontrol/ cameracontrol/
-
-log "Download rc-encrypted"
-# sudo git clone https://github.com/user1321/wifibroadcast-rc-encrypted
-sudo mv Open.HD/wifibroadcast-rc-encrypted/ wifibroadcast-rc-encrypted/
 
 log "Download JoystickIn"
 # sudo git clone https://github.com/user1321/JoystickIn


### PR DESCRIPTION
These will still be available in the git history if we need to refer to them for some reason, but they are entirely unused even when the encrypted RC mode is set, the Ath9k RC code includes support for it and simply has a slightly misleading name at the moment.