### PR TITLE
Increase UDP buffer size, default is very low

### DIFF
--- a/stages/05-Wifibroadcast/FILES/overlay/etc/sysctl.d/98-rpi.conf
+++ b/stages/05-Wifibroadcast/FILES/overlay/etc/sysctl.d/98-rpi.conf
@@ -5,3 +5,5 @@ vm.min_free_kbytes = 8192
 vm.dirty_background_ratio = 1
 vm.dirty_ratio = 2
 vm.dirty_writeback_centisecs = 25
+net.core.rmem_max = 2621440
+net.core.rmem_default = 2621440


### PR DESCRIPTION
This may impact some of the pipelines on both the air and ground side,
which are in some cases sending and receiving UDP packets on the same
system.

For example the hotspot video handling is sent from a gstreamer
pipeline to udpsplitter.py, and that creates a point where
the buffer size being slightly too small could prevent the splitter
from processing all data before the buffer becomes full.

Since we're using video bitrates that peak to around 1MB/s, it's not
out of the question that a single I frame could be larger than the
existing buffer size.

This commit increases the default to around 2.5MB, which should be
enough for at least 2-3 seconds in most cases, ensuring the data isn't
lost.

This should not affect latency unless the processes handling the data
can't process it fast enough, but that would not be fixed by using a
smaller buffer anyway. In other words it's a FIFO, not a jitter
buffer.