### PR TITLE
Add temporary special case for building CM3+ images

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,12 @@
 #!/bin/bash -e
 # shellcheck disable=SC2119,SC1091
 
+IMAGE_TYPE=$1
+
+if [[ "${IMAGE_TYPE}" == "" ]]; then
+	IMAGE_TYPE="pi"
+fi
+
 run_stage(){
 	log "Begin ${STAGE_DIR}"
 	STAGE="$(basename "${STAGE_DIR}")"
@@ -88,12 +94,32 @@ export LOG_FILE="${WORK_DIR}/build.log"
 
 mkdir -p "${WORK_DIR}"
 
-# Get the dynamic information from the image
-curl $BASE_IMAGE_URL/$BASE_IMAGE".info" > $WORK_DIR/infofile
 
-GIT_KERNEL_SHA1=$(cat $WORK_DIR/infofile | grep -Po '\b(Kernel: https:\/\/github\.com\/raspberrypi\/linux\/tree\/\K)+(.*)$')
-KERNEL_VERSION_V7=$(cat $WORK_DIR/infofile | grep -Po '\b(Uname string: Linux version )\K(?<price>[^\ ]+)')
-KERNEL_VERSION=${KERNEL_VERSION_V7%"-v7+"}"+"
+
+if [[ "$IMAGE_TYPE" == "pi" || "$IMAGE_TYPE" == "pizero" || "$IMAGE_TYPE" == "pi2" || "$IMAGE_TYPE" == "pi3" ]]; then
+	BASE_IMAGE_URL=${PI_STRETCH_BASE_IMAGE_URL}
+	BASE_IMAGE=${PI_STRETCH_BASE_IMAGE}
+	IMAGE_ARCH="pi"
+	KERNEL_BRANCH=${PI_STRETCH_KERNEL_BRANCH}
+fi
+
+
+if [[ "$IMAGE_TYPE" == "cm3p" ]]; then
+	BASE_IMAGE_URL=${PICM3P_STRETCH_BASE_IMAGE_URL}
+	BASE_IMAGE=${PICM3P_STRETCH_BASE_IMAGE}
+	IMAGE_ARCH="pi"
+	KERNEL_BRANCH=${PICM3P_STRETCH_KERNEL_BRANCH}
+fi
+
+if [[ "$IMAGE_TYPE" == "pi" || "$IMAGE_TYPE" == "pizero" || "$IMAGE_TYPE" == "pi2" || "$IMAGE_TYPE" == "pi3" || "$IMAGE_TYPE" == "cm3p" ]]; then
+	# Get the dynamic information from the image
+	curl "${BASE_IMAGE_URL}/${BASE_IMAGE}.info" > $WORK_DIR/infofile
+
+	GIT_KERNEL_SHA1=$(cat $WORK_DIR/infofile | grep -Po '\b(Kernel: https:\/\/github\.com\/raspberrypi\/linux\/tree\/\K)+(.*)$')
+	KERNEL_VERSION_V7=$(cat $WORK_DIR/infofile | grep -Po '\b(Uname string: Linux version )\K(?<price>[^\ ]+)')
+	KERNEL_VERSION=${KERNEL_VERSION_V7%"-v7+"}"+"
+fi
+
 
 # used in the stage 5 scripts to place a version file inside the image, and below after the
 # stages have run, in the name of the image itself
@@ -102,6 +128,11 @@ export BUILDER_VERSION
 
 
 export BASE_DIR
+
+export IMAGE_TYPE
+export IMAGE_ARCH
+export BASE_IMAGE_URL
+export BASE_IMAGE
 
 export CLEAN
 export IMG_NAME
@@ -120,8 +151,8 @@ export QOPENHD_VERSION
 export PI_TOOLS_REPO
 export PI_TOOLS_BRANCH
 
-export PI_KERNEL_REPO
-export PI_KERNEL_BRANCH
+export KERNEL_REPO
+export KERNEL_BRANCH
 
 export RTL_8812AU_REPO
 export RTL_8812AU_BRANCH

--- a/buildwithlog.sh
+++ b/buildwithlog.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-./build.sh |& tee buildlog.log
+./build.sh $1 |& tee buildlog.log

--- a/config
+++ b/config
@@ -1,11 +1,18 @@
 # Output image name
 IMG_NAME=Open.HD
 
-# Download location base image
-BASE_IMAGE_URL="http://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2018-10-11"
+KERNEL_REPO=https://github.com/raspberrypi/linux.git
 
-# File name base image
-BASE_IMAGE="2018-10-09-raspbian-stretch-lite"
+
+PI_STRETCH_BASE_IMAGE_URL="http://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2018-10-11"
+PI_STRETCH_BASE_IMAGE="2018-10-09-raspbian-stretch-lite"
+PI_STRETCH_KERNEL_BRANCH=rpi-4.14.y
+
+PICM3P_STRETCH_BASE_IMAGE_URL="http://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-04-09"
+PICM3P_STRETCH_BASE_IMAGE="2019-04-08-raspbian-stretch-lite"
+PICM3P_STRETCH_KERNEL_BRANCH=rpi-4.14.y
+
+
 
 # Amount of cores to use for compilation on host machine
 J_CORES=12
@@ -16,9 +23,6 @@ APT_CACHER_NG_ENABLED=false
 
 PI_TOOLS_REPO=https://github.com/raspberrypi/tools.git
 PI_TOOLS_BRANCH=master
-
-PI_KERNEL_REPO=https://github.com/raspberrypi/linux.git
-PI_KERNEL_BRANCH=rpi-4.14.y
 
 # Fixed at v5.2.20 until 5.3.4 works for injection
 RTL_8812AU_REPO=https://github.com/aircrack-ng/rtl8812au.git

--- a/stages/02-Kernel/00-run.sh
+++ b/stages/02-Kernel/00-run.sh
@@ -5,7 +5,7 @@ pushd ${STAGE_WORK_DIR}
 
 if [ ! -d "linux" ]; then
     log "Download the kernel"
-    git clone --depth=1 -b ${KERNEL_BRANCH} ${KERNEL_REPO}
+    git clone --depth=100 -b ${KERNEL_BRANCH} ${KERNEL_REPO}
 fi
 
 pushd linux

--- a/stages/02-Kernel/00-run.sh
+++ b/stages/02-Kernel/00-run.sh
@@ -4,8 +4,8 @@ set -e
 pushd ${STAGE_WORK_DIR}
 
 if [ ! -d "linux" ]; then
-    log "Download the Raspberry Pi Kernel"
-    git clone --depth=1 -b ${PI_KERNEL_BRANCH} ${PI_KERNEL_REPO}
+    log "Download the kernel"
+    git clone --depth=1 -b ${KERNEL_BRANCH} ${KERNEL_REPO}
 fi
 
 pushd linux


### PR DESCRIPTION
This adds an argument to build.sh to allow building images for other pi models that do not work with the current base image, like the CM3+.

Once we know the newer image works for the other pi models as well, we can simply update the normal image and remove the special casing.

Pi4 support will be added in a similar way, a temporary special case until the newer buster image is well tested on pi zero and pi3.