### PR TITLE
Use our own fork of v4l2loopback

### DIFF
--- a/config
+++ b/config
@@ -28,8 +28,8 @@ PI_TOOLS_BRANCH=master
 RTL_8812AU_REPO=https://github.com/aircrack-ng/rtl8812au.git
 RTL_8812AU_BRANCH=v5.2.20
 
-V4L2LOOPBACK_REPO=https://github.com/RespawnDespair/v4l2loopback.git
-V4L2LOOPBACK_BRANCH=master
+V4L2LOOPBACK_REPO=https://github.com/OpenHD/v4l2loopback.git
+V4L2LOOPBACK_BRANCH=openhd1
 
 VEYE_REPO=https://github.com/OpenHD/veye_raspberrypi.git
 VEYE_BRANCH=openhd1


### PR DESCRIPTION
This pins the version we use at a specific commit, and keeps the code under our own organization so it doesn't suddenly change.