### PR TITLE
Build the RC transmit code in stage 5

### DIFF
--- a/stages/03-Packages/00-run-chroot.sh
+++ b/stages/03-Packages/00-run-chroot.sh
@@ -70,6 +70,7 @@ MESA_DRM_STACK="libegl1-mesa libegl1-mesa-dev libgles2-mesa libgles2-mesa-dev li
 
 MICROSERVICE_DEPENDENCIES="libboost-dev libboost-program-options-dev libboost-system-dev libasio-dev"
 
+RC_DEPENDENCIES="libboost-regex-dev libboost-filesystem-dev libboost-thread-dev"
 
 TEXTTOSPEECH_QOPENHD="libspeechd-dev flite1-dev flite speech-dispatcher-flite"
 
@@ -101,6 +102,7 @@ ${NETWORK_UTILITIES} \
 ${DEVELOPMENT_UTILITIES} \
 ${MESA_DRM_STACK} \
 ${MICROSERVICE_DEPENDENCIES} \
+${RC_DEPENDENCIES} \
 ${TEXTTOSPEECH_QOPENHD} \
 ${QT_DEPENDENCIES} \
 ${GSTREAMER} ${GNUPLOT} || exit 1

--- a/stages/05-Wifibroadcast/01-run-chroot.sh
+++ b/stages/05-Wifibroadcast/01-run-chroot.sh
@@ -105,8 +105,7 @@ chmod 755 version.py
 make
 ./wfb_keygen
 
-sudo chmod 775 /home/pi/wifibroadcast-rc-Ath9k/rctxUDP.sh
-sudo chmod 775 /home/pi/wifibroadcast-rc-Ath9k/rctxUDP_IN
+
 
 cd /home/pi/wifibroadcast-rc-Ath9k
 sudo chmod 775 /home/pi/wifibroadcast-rc-Ath9k/buildlora.sh

--- a/stages/05-Wifibroadcast/01-run-chroot.sh
+++ b/stages/05-Wifibroadcast/01-run-chroot.sh
@@ -112,6 +112,11 @@ cd /home/pi/wifibroadcast-rc-Ath9k
 sudo chmod 775 /home/pi/wifibroadcast-rc-Ath9k/buildlora.sh
 sudo /home/pi/wifibroadcast-rc-Ath9k/buildlora.sh
 sudo chmod 775 /home/pi/wifibroadcast-rc-Ath9k/lora
+sudo chmod 775 /home/pi/wifibroadcast-rc-Ath9k/build.sh
+sudo /home/pi/wifibroadcast-rc-Ath9k/build.sh
+sudo chmod 775 /home/pi/wifibroadcast-rc-Ath9k/rctx
+cp /home/pi/wifibroadcast-rc-Ath9k/rctx /usr/local/bin/
+
 
 
 cd /home/pi/wifibroadcast-misc/LCD

--- a/stages/05-Wifibroadcast/01-run-chroot.sh
+++ b/stages/05-Wifibroadcast/01-run-chroot.sh
@@ -112,6 +112,8 @@ cd /home/pi/wifibroadcast-rc-Ath9k
 sudo chmod 775 /home/pi/wifibroadcast-rc-Ath9k/buildlora.sh
 sudo /home/pi/wifibroadcast-rc-Ath9k/buildlora.sh
 sudo chmod 775 /home/pi/wifibroadcast-rc-Ath9k/lora
+cp /home/pi/wifibroadcast-rc-Ath9k/lora /usr/local/bin/
+
 sudo chmod 775 /home/pi/wifibroadcast-rc-Ath9k/build.sh
 sudo /home/pi/wifibroadcast-rc-Ath9k/build.sh
 sudo chmod 775 /home/pi/wifibroadcast-rc-Ath9k/rctx


### PR DESCRIPTION
The RC transmit side code no longer needs to be built during boot, the scripts and arguments have been removed and now it reads its own settings files directly.