### PR TITLE
Update the central copy of the mavlink library

### DIFF
--- a/config
+++ b/config
@@ -46,7 +46,7 @@ RASPI2PNG_REPO=https://github.com/OpenHD/raspi2png.git
 RASPI2PNG_BRANCH=openhd1
 
 MAVLINK_REPO=https://github.com/infincia/mavlink.git
-MAVLINK_BRANCH=openhd2
+MAVLINK_BRANCH=openhd3
 
 MAVLINK_ROUTER_REPO=https://github.com/OpenHD/mavlink-router.git
 MAVLINK_ROUTER_BRANCH=openhd1

--- a/stages/05-Wifibroadcast/01-run-chroot.sh
+++ b/stages/05-Wifibroadcast/01-run-chroot.sh
@@ -133,4 +133,12 @@ cd /home/pi/QOpenHD
 make -j5 || exit 1
 cp -a release/QOpenHD "/usr/local/bin/QOpenHD" || exit 1
 cd ..
+
+cd /home/pi/QOpenHD/OpenHDBoot
+/opt/Qt${QT_VERSION}/bin/qmake || exit 1
+make -j5 || exit 1
+cp -a OpenHDBoot "/usr/local/bin/OpenHDBoot" || exit 1
+cd ..
+cd ..
+
 rm -rf QOpenHD

--- a/stages/05-Wifibroadcast/FILES/overlay/etc/systemd/system/openhdboot.service
+++ b/stages/05-Wifibroadcast/FILES/overlay/etc/systemd/system/openhdboot.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=OpenHDBoot
+After=multi-user.target
+
+[Service]
+Type=simple
+Environment="LD_PRELOAD=/opt/vc/lib/libGLESv2.so /opt/vc/lib/libEGL.so"
+Environment="QT_QPA_EGLFS_ALWAYS_SET_MODE=1"
+ExecStart=/usr/local/bin/OpenHDBoot -platform eglfs
+User=root
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
This includes the status messages and a set of messages for checking the version of Open.HD running on the ground and air side, which is used to show the version to users, warn about mismatches, and facilitate offline upgrades.