### PR TITLE
Build the old OSD in stage 5, add systemd unit

### DIFF
--- a/stages/05-Wifibroadcast/01-run-chroot.sh
+++ b/stages/05-Wifibroadcast/01-run-chroot.sh
@@ -119,6 +119,10 @@ sudo chmod 775 /home/pi/wifibroadcast-rc-Ath9k/rctx
 cp /home/pi/wifibroadcast-rc-Ath9k/rctx /usr/local/bin/
 
 
+cd /home/pi/wifibroadcast-osd
+make -j5 || exit 1
+cd ..
+
 
 cd /home/pi/wifibroadcast-misc/LCD
 sudo make

--- a/stages/05-Wifibroadcast/FILES/overlay/etc/systemd/system/osd.service
+++ b/stages/05-Wifibroadcast/FILES/overlay/etc/systemd/system/osd.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=OSD
+After=multi-user.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/osd
+User=root
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
This is now possible because it reads its own settings instead of requiring to be compiled at boot time.

To restart it, just run:

    systemctl restart osd