### PR TITLE
Don't advertise gateway/dns to hotspot DHCP client

### DIFF
--- a/stages/05-Wifibroadcast/FILES/overlay/etc/dnsmasqEth0.conf
+++ b/stages/05-Wifibroadcast/FILES/overlay/etc/dnsmasqEth0.conf
@@ -334,6 +334,12 @@ dhcp-range=eth0,192.168.1.2,192.168.1.50,2m
 # router is the same machine as the one running dnsmasq.
 #dhcp-option=3,1.2.3.4
 
+# disable router advertisement
+dhcp-option=3
+
+# don't claim to be a DNS server
+dhcp-option=6
+
 # Do the same thing, but using the option name
 #dhcp-option=option:router,1.2.3.4
 

--- a/stages/05-Wifibroadcast/FILES/overlay/etc/dnsmasqWifi.conf
+++ b/stages/05-Wifibroadcast/FILES/overlay/etc/dnsmasqWifi.conf
@@ -334,6 +334,12 @@ dhcp-range=wifihotspot0,192.168.2.2,192.168.2.50,2m
 # router is the same machine as the one running dnsmasq.
 #dhcp-option=3,1.2.3.4
 
+# disable router advertisement
+dhcp-option=3
+
+# don't claim to be a DNS server
+dhcp-option=6
+
 # Do the same thing, but using the option name
 #dhcp-option=option:router,1.2.3.4
 


### PR DESCRIPTION
The `dnsmasq` service was telling hotspot clients that the ground station was a router capable of being a default gateway, and to route DNS requests to it.

Advertising a default gateway and DNS causes android phones to route traffic to the ground station even when they could use LTE normally, which makes it impossible to use anything requiring internet access while connected to the openhd hotspot.