### PR TITLE
Turn hotspot power back up by default

### DIFF
--- a/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-1.txt
+++ b/stages/05-Wifibroadcast/FILES/overlay/boot/openhd-settings-1.txt
@@ -165,7 +165,7 @@ HOTSPOT_CHANNEL=36
 HOTSPOT_TIMEOUT=0
 # hotspot transmit power in units of mBm, so 100 corresponds to 1dBm
 # to set full power, use HOTSPOT_TXPOWER=3100
-HOTSPOT_TXPOWER=100
+HOTSPOT_TXPOWER=3100
 
 # >>>>>>>>>>[ETHERNET HOTSPOT]--*Only used for PC/Mission Planner Ethernet connection
 # Set this to "Y" to enable Ethernet hotspot. This will forward the received video and 


### PR DESCRIPTION
In practice we just end up telling everyone to turn it up again when they have problems