### PR TITLE
Remove man-db package in stage 3

### DIFF
--- a/stages/03-Packages/00-run-chroot.sh
+++ b/stages/03-Packages/00-run-chroot.sh
@@ -86,7 +86,7 @@ GSTREAMER="libgstreamer1.0-0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good
 
 
 PURGE="wireless-regdb crda cron apt-transport-https aptitude aptitude-common apt-listchanges
-       avahi-daemon cifs-utils curl iptables triggerhappy"
+       avahi-daemon cifs-utils curl iptables triggerhappy man-db"
 
 
 DEBIAN_FRONTEND=noninteractive sudo apt-get -y --no-install-recommends install \


### PR DESCRIPTION
The periodic cron job that man-db comes with can use a ton of CPU, and
that can occur at unexpected times when people are flying, which can
affect the video.