### PR TITLE
Update buster base, kernel

### DIFF
--- a/config
+++ b/config
@@ -11,8 +11,8 @@ PI_STRETCH_KERNEL_COMMIT="f7b90465e3a1c70394ad441eb8515fa0f80b9fb5"
 
 PI_BUSTER_BASE_IMAGE_URL="http://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2020-05-28"
 PI_BUSTER_BASE_IMAGE="2020-05-27-raspios-buster-lite-armhf"
-PI_BUSTER_KERNEL_BRANCH=rpi-4.19.y-openhd
-PI_BUSTER_KERNEL_COMMIT="beabba1829b5874d114433a76154922094da957f"
+PI_BUSTER_KERNEL_BRANCH=rpi-4.19.122-openhd
+PI_BUSTER_KERNEL_COMMIT="0bf946db01701cdeeba0be32207b7df3aa3520fa"
 
 # Amount of cores to use for compilation on host machine
 J_CORES=12

--- a/config
+++ b/config
@@ -9,8 +9,8 @@ PI_STRETCH_BASE_IMAGE="2018-10-09-raspbian-stretch-lite"
 PI_STRETCH_KERNEL_BRANCH=rpi-4.14.71-openhd
 PI_STRETCH_KERNEL_COMMIT="f7b90465e3a1c70394ad441eb8515fa0f80b9fb5"
 
-PI_BUSTER_BASE_IMAGE_URL="http://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2020-02-14"
-PI_BUSTER_BASE_IMAGE="2020-02-13-raspbian-buster-lite"
+PI_BUSTER_BASE_IMAGE_URL="http://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2020-05-28"
+PI_BUSTER_BASE_IMAGE="2020-05-27-raspios-buster-lite-armhf"
 PI_BUSTER_KERNEL_BRANCH=rpi-4.19.y-openhd
 PI_BUSTER_KERNEL_COMMIT="beabba1829b5874d114433a76154922094da957f"
 


### PR DESCRIPTION
This updates the buster base image to 2020-5-27, which is technically called raspios now but that makes no difference to us.

This updates the firmware a little which probably fixes a few quirks/bugs we may or may not have seen in practice.

This also updates the buster kernel to `rpi-4.19.122-openhd` on a separate branch, and in that branch we have reverted 2 specific commits that directly affect USB joysticks. We have seen 2 bugs in practice, one that causes RC channel 8 to appear dead and with that bug fix, another bug that causes RC channel 8 to affect RC channel 7. Both are pretty serious and reverting specific commits from the upstream kernel appears to be the only way to fix that at the moment.

In the future we may end up needing to use a userspace libusb joystick system instead of the kernel drivers, in order to insulate us from those kinds of kernel problems. The Android RC app already works this way, parsing the USB device descriptor and reading the axis values entirely in the app itself.



