### PR TITLE
Use QOpenHD package instead of rebuilding it

### DIFF
--- a/stages/05-Wifibroadcast/01-run-chroot.sh
+++ b/stages/05-Wifibroadcast/01-run-chroot.sh
@@ -132,17 +132,15 @@ chmod 755 /home/pi/wifibroadcast-misc/LCD/MouseListener
  rm /etc/init.d/dhcpcd
 
 
-cd /home/pi/QOpenHD
-/opt/Qt${QT_VERSION}/bin/qmake || exit 1
-make -j5 || exit 1
-cp -a release/QOpenHD "/usr/local/bin/QOpenHD" || exit 1
-cd ..
+#
+# this is a temporary step to reduce the image build time just like the qt package.
+# in 2.1 we will use real deb packages
+cd /home/pi/
+QOPENHD_PACKAGE="QOpenHD-${QOPENHD_VERSION}-${IMAGE_ARCH}-${DISTRO}-Qt${QT_VERSION}-${QT_MINOR_RELEASE}.tar.gz"
+QOPENHD_PACKAGE_URL="${QOPENHD_REPO%.*}/releases/download/${QOPENHD_VERSION}/${QOPENHD_PACKAGE}"
+wget ${QOPENHD_PACKAGE_URL} || exit 1
+tar xvf ${QOPENHD_PACKAGE} || exit 1
+mv QOpenHD /usr/local/bin/ || exit 1
+mv OpenHDBoot /usr/local/bin/ || exit 1
+rm ${QOPENHD_PACKAGE} || exit 1
 
-cd /home/pi/QOpenHD/OpenHDBoot
-/opt/Qt${QT_VERSION}/bin/qmake || exit 1
-make -j5 || exit 1
-cp -a OpenHDBoot "/usr/local/bin/OpenHDBoot" || exit 1
-cd ..
-cd ..
-
-rm -rf QOpenHD

--- a/stages/05-Wifibroadcast/01-run.sh
+++ b/stages/05-Wifibroadcast/01-run.sh
@@ -89,14 +89,6 @@ sudo mv Open.HD/UDPSplitter/ UDPSplitter/
 
 sudo rm -rf Open.HD
 
-
-git clone --depth=1 -b ${QOPENHD_VERSION} ${QOPENHD_REPO} || exit 1
-cd QOpenHD
-git submodule update --init --recursive || exit 1
-echo ${OPENHD_VERSION} > .openhd_version
-echo ${BUILDER_VERSION} > .builder_version
-cd ..
-
 #return
 popd
 popd


### PR DESCRIPTION
This is a temporary step to eliminate a huge part of the build process, the tar archive is trivially easy to build and unpack. It should reduce the image build time by probably 45-60 minutes.

This is going to be replaced with a deb package like everything else in OpenHD 2.1. The work on that is about 70% done already it's just waiting for 2.0 to be released before merging since it will need more testing.