### PR TITLE
Prevent OpenHDBoot, QOpenHD from changing KMS mode

### DIFF
--- a/stages/05-Wifibroadcast/FILES/overlay/etc/openhd/qt.json
+++ b/stages/05-Wifibroadcast/FILES/overlay/etc/openhd/qt.json
@@ -1,0 +1,19 @@
+{
+    "device": "/dev/dri/by-path/platform-soc:gpu-card",
+    "hwcursor": false,
+    "pbuffers": true,
+    "outputs": [
+      {
+        "name": "HDMI1",
+        "mode": "current"
+      },
+      {
+        "name": "HDMI2",
+        "mode": "current"
+      },
+      {
+        "name": "DSI1",
+        "mode": "current"
+      }
+    ]
+  }

--- a/stages/05-Wifibroadcast/FILES/overlay/etc/systemd/system/openhdboot.service
+++ b/stages/05-Wifibroadcast/FILES/overlay/etc/systemd/system/openhdboot.service
@@ -5,6 +5,7 @@ After=multi-user.target
 [Service]
 Type=simple
 Environment="LD_PRELOAD=/opt/vc/lib/libGLESv2.so /opt/vc/lib/libEGL.so"
+Environment="QT_QPA_EGLFS_KMS_CONFIG=/qt.json"
 Environment="QT_QPA_EGLFS_KMS_ATOMIC=1"
 ExecStart=/usr/local/bin/OpenHDBoot -platform eglfs
 User=root

--- a/stages/05-Wifibroadcast/FILES/overlay/etc/systemd/system/qopenhd.service
+++ b/stages/05-Wifibroadcast/FILES/overlay/etc/systemd/system/qopenhd.service
@@ -5,6 +5,7 @@ After=multi-user.target
 [Service]
 Type=simple
 Environment="LD_PRELOAD=/opt/vc/lib/libGLESv2.so /opt/vc/lib/libEGL.so"
+Environment="QT_QPA_EGLFS_KMS_CONFIG=/qt.json"
 Environment="QT_QPA_EGLFS_KMS_ATOMIC=1"
 ExecStart=/usr/local/bin/QOpenHD -platform eglfs
 User=root

--- a/stages/05-Wifibroadcast/FILES/overlay/usr/local/bin/run_qopenhd
+++ b/stages/05-Wifibroadcast/FILES/overlay/usr/local/bin/run_qopenhd
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-LD_PRELOAD="/opt/vc/lib/libGLESv2.so /opt/vc/lib/libEGL.so" QT_QPA_EGLFS_KMS_ATOMIC=1 /usr/local/bin/QOpenHD -platform eglfs
+LD_PRELOAD="/opt/vc/lib/libGLESv2.so /opt/vc/lib/libEGL.so" QT_QPA_EGLFS_KMS_CONFIG=/etc/openhd/qt.json QT_QPA_EGLFS_KMS_ATOMIC=1 /usr/local/bin/QOpenHD -platform eglfs


### PR DESCRIPTION
With certain HDMI devices, the Pi firmware and the Linux kernel don't
have the same view of what the preferred screen resolution/mode should
be.

As a result, the pi firmware picks one resolution/mode, but then the
boot screen and QOpenHD are told by the linux kernel that a different
resolution is preferred, so they switch to it.

This severely breaks things, resulting in missing video and other
problems, but only affecting devices like the Headplay goggles.

Only affects Buster because Stretch is not using the KMS display
stack.