### PR TITLE
Allow Journal.d on Ubuntu (jetson)

### DIFF
--- a/stages/03-Preconfiguration/00-run-chroot.sh
+++ b/stages/03-Preconfiguration/00-run-chroot.sh
@@ -46,7 +46,10 @@ sudo systemctl disable dhcpcd.service
 sudo systemctl disable dnsmasq.service
 sudo systemctl disable cron.service
 sudo systemctl disable syslog.service
-sudo systemctl disable journald.service
+if [[ "${OS}" != "ubuntu" ]]; then
+    echo "OS is NOT ubuntu..disabling journald"
+    sudo systemctl disable journald.service
+fi
 sudo systemctl disable triggerhappy.service
 sudo systemctl disable avahi-daemon.service
 sudo systemctl disable ser2net.service
@@ -61,15 +64,21 @@ sudo systemctl mask plymouth-start.service
 sudo systemctl mask plymouth-read-write.service
 sudo systemctl mask plymouth-quit-wait.service
 sudo systemctl mask plymouth-quit.service
-sudo systemctl disable systemd-journal-flush.service
+if [[ "${OS}" != "ubuntu" ]]; then
+    echo "OS is NOT ubuntu..disabling journald flush"
+    sudo systemctl disable systemd-journal-flush.service
+fi
 #this service updates runlevel changes. Set desired runlevel prior to this being disabled
 sudo systemctl disable systemd-update-utmp.service
 sudo systemctl disable networking.service
 
 #Mask difficult to disable services
-systemctl stop systemd-journald.service
-systemctl disable systemd-journald.service
-systemctl mask systemd-journald.service
+if [[ "${OS}" != "ubuntu" ]]; then
+    echo "OS is NOT ubuntu..stopping-disbale-mask journald"
+    systemctl stop systemd-journald.service
+    systemctl disable systemd-journald.service
+    systemctl mask systemd-journald.service
+fi
 
 
 sudo rm /etc/init.d/resize2fs_once

--- a/stages/03-Preconfiguration/99-run.sh
+++ b/stages/03-Preconfiguration/99-run.sh
@@ -6,7 +6,7 @@ cp ${STAGE_WORK_DIR}/mnt/openhd_version.txt ${WORK_DIR}/openhd_version.txt
 
 MNT_DIR="${STAGE_WORK_DIR}/mnt"
 
-if [[ "${HAVE_CONF_FAKE}" == "false" ]] && [[ "${HAVE_BOOT_PART}" == "true" ]]; then
+if [[ "${HAVE_CONF_PART}" == "false" ]] && [[ "${HAVE_BOOT_PART}" == "true" ]]; then
 # Rename the DOS partition
     BOOT_MNT_DIR="${STAGE_WORK_DIR}/mnt/boot"
     BOOT_LOOP_DEV="$(findmnt -nr -o source $BOOT_MNT_DIR)"


### PR DESCRIPTION
This fix eliminates the errors related to logging and other things during start. Also allows the kernel module services to start