### PR TITLE
repair partitioning for jetson-io

### DIFF
--- a/stages/01-Baseimage/01-run.sh
+++ b/stages/01-Baseimage/01-run.sh
@@ -59,6 +59,7 @@ ${ROOT_OFFSET}
 w
 EOF
 fi
+sgdisk -c 1:APP IMAGE.img
 
 rm temp.img
 


### PR DESCRIPTION
Rename first partition, so that jetson-io is working again.