### PR TITLE
change to newest base

### DIFF
--- a/images/pi-bullseye
+++ b/images/pi-bullseye
@@ -1,6 +1,6 @@
-BASE_IMAGE_URL="http://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-11-08/"
-BASE_IMAGE="2021-10-30-raspios-bullseye-armhf-lite.zip"
-BASE_IMAGE_SHA256="008d7377b8c8b853a6663448a3f7688ba98e2805949127a1d9e8859ff96ee1a9"
+BASE_IMAGE_URL="http://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2022-01-28/"
+BASE_IMAGE="2022-01-28-raspios-bullseye-armhf-lite.zip"
+BASE_IMAGE_SHA256="f6e2a3e907789ac25b61f7acfcbf5708a6d224cf28ae12535a2dc1d76a62efbc"
 OS="raspbian"
 DISTRO="bullseye"
 HAS_CUSTOM_KERNEL=true


### PR DESCRIPTION
There has been a new base image for raspios lite released. Trying this image to see if it fixes binary issues. Do not merge yet, this pull is to test the build.