### PR TITLE
Update 00-run-chroot.sh | missing obs-studio | add-apt-repository -y

### DIFF
--- a/stages/03-Preconfiguration/00-run-chroot.sh
+++ b/stages/03-Preconfiguration/00-run-chroot.sh
@@ -144,7 +144,7 @@ if [[ "${OS}" == "ubuntu-x86" ]] ; then
        gio set /home/openhd/Desktop/MissionPlanner.desktop metadata::trusted true
        gio set /home/openhd/Desktop/qgroundcontrol.desktop metadata::trusted true
        echo "openhd ALL=(ALL:ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/openhd
-       sudo add-apt-repository ppa:obsproject/obs-studio
+       sudo add-apt-repository -y ppa:obsproject/obs-studio
        sudo apt install -y obs-studio
        cd /opt
        mkdir MissionPlanner


### PR DESCRIPTION
obs-studio is missing from latest usb-image. Suspect that add-apt-repository needs to be automated with -y

Log file when trying to run obs-studio on latest x86 image. Including with and without -y

[missing-obs.log](https://github.com/OpenHD/OpenHD-ImageBuilder/files/13845621/missing-obs.log)
