### PR TITLE
Use correct location of dekstop-truster.sh in X86-installer.sh

### DIFF
--- a/X86-Installer.sh
+++ b/X86-Installer.sh
@@ -31,7 +31,7 @@ installShortcuts()
 {
     echo "Installing shortcuts..."
     cd /opt/X86/
-    cp additionalFiles/desktop-truster.sh /etc/profile.d/desktop-truster.sh || { echo "Failed to copy desktop-truster.sh"; exit 1; }
+    cp desktop-truster.sh /etc/profile.d/desktop-truster.sh || { echo "Failed to copy desktop-truster.sh"; exit 1; }
     chmod +777 /etc/profile.d/desktop-truster.sh
     chmod a+x /etc/profile.d/desktop-truster.sh
     chmod a+x shortcuts/OpenHD-Air.desktop


### PR DESCRIPTION
I tried these instructions: [Installing OpenHD on X86](https://openhd.gitbook.io/open-hd/hardware/sbcs/x86) to install OpenHD on a fresh Ubuntu 22.04 desktop installation.
It seems the script tries to read `desktop-truster.sh` from the `additionalFiles` directory, while it actually is located in the root.