### PR TITLE
Use base metadata for update mode

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -66,12 +66,21 @@ if [[ "${IMAGE_TYPE}" == "" ]]; then
     exit 1
 fi
 
-if [[ ! -f ./images/${IMAGE_TYPE} ]]; then
-    echo "Invalid image type: ${IMAGE_TYPE}"
+IMAGE_METADATA_FILE="./images/${IMAGE_TYPE}"
+if [[ "${UPDATE_MODE}" == "true" ]]; then
+    IMAGE_METADATA_FILE="./images/${IMAGE_TYPE}_base"
+fi
+
+if [[ ! -f "${IMAGE_METADATA_FILE}" ]]; then
+    if [[ "${UPDATE_MODE}" == "true" ]]; then
+        echo "Invalid image type for update workflow: ${IMAGE_TYPE}_base"
+    else
+        echo "Invalid image type: ${IMAGE_TYPE}"
+    fi
     exit 1
 fi
 
-source ./images/${IMAGE_TYPE}
+source "${IMAGE_METADATA_FILE}"
 
 echo ""
 line


### PR DESCRIPTION
## Summary
- ensure the update workflow sources board metadata from the corresponding `_base` file (e.g. `pi-bullseye_base`)
- provide clearer error messaging when a required metadata file is missing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69188df939dc832f8d123973c7f80b9c)