### PR TITLE
Allow qopenhd package override

### DIFF
--- a/images/radxa-cm3
+++ b/images/radxa-cm3
@@ -2,6 +2,7 @@ BASE_IMAGE_URL="https://fra1.digitaloceanspaces.com/openhd-images/Downloader/rel
 BASE_IMAGE="OpenHD-image-radxa-cm3--release-06-26-2024-00-29-10.img.xz"
 BASE_IMAGE_SHA256="36e5c95544de75236a92e7947364f29fd58e7fdcf1acb26deac12c3b9fa9954b"
 OS="radxa-debian-rock-cm3"
+QOPENHD_PACKAGE="qopenhd-rk3566"
 DISTRO="bullseye"
 HAVE_BOOT_PART=false
 HAVE_CONF_PART=true

--- a/images/rock5a_base
+++ b/images/rock5a_base
@@ -2,6 +2,7 @@ BASE_IMAGE_URL="https://fra1.digitaloceanspaces.com/openhd-images/Downloader/rel
 BASE_IMAGE="OpenHD-image-rock5a--release-06-26-2024-00-29-36.img.xz"
 BASE_IMAGE_SHA256="b4d349ca55fc1d6dcfefeb33ae106471d1ed8e9fe5ed61baa109b7d9ff8a1fe9"
 OS="radxa-debian-rock5a"
+QOPENHD_PACKAGE="qopenhd-rk3588"
 DISTRO="bullseye"
 HAVE_BOOT_PART=false
 HAVE_CONF_PART=false

--- a/images/rock5b_base
+++ b/images/rock5b_base
@@ -2,6 +2,7 @@ BASE_IMAGE_URL="https://fra1.digitaloceanspaces.com/openhd-images/Downloader/rel
 BASE_IMAGE="OpenHD-image-rock5b--release-06-26-2024-00-28-57.img.xz"
 BASE_IMAGE_SHA256="0e6ce03f8e2a381873856a2d7cc4e93fc6b476c4c9414e9293fe7224ba2783ac"
 OS="radxa-debian-rock5b"
+QOPENHD_PACKAGE="qopenhd-rk3588"
 DISTRO="bullseye"
 HAVE_BOOT_PART=false
 HAVE_CONF_PART=false

--- a/stages/Update/update.sh
+++ b/stages/Update/update.sh
@@ -74,10 +74,12 @@ fi
 $APT install openhd libpoco-dev
 
 # Install qopenhd or fallback
+qopenhd_package="${QOPENHD_PACKAGE:-qopenhd}"
+
 if [[ "${OS}" == "radxa-debian-cubie" ]]; then
   $APT install v4l-utils
 else
-  $APT install "qopenhd" || true
+  $APT install "${qopenhd_package}" || true
 fi
 
 # Enable service


### PR DESCRIPTION
## Summary
- allow update script to install a configurable qopenhd package instead of a fixed default
- set qopenhd package identifiers for the CM3 and Rock5 images

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693315c69c24832f8a94a6feae07e821)